### PR TITLE
Add Cross-Origin Resource Sharing support

### DIFF
--- a/src/main/java/uk/org/funcube/fcdw/config/AppConfig.java
+++ b/src/main/java/uk/org/funcube/fcdw/config/AppConfig.java
@@ -24,6 +24,7 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
@@ -140,6 +141,11 @@ public class AppConfig extends WebMvcConfigurerAdapter {
 		registry.addResourceHandler("/images/**").addResourceLocations(
 				"/images/");
 		registry.addResourceHandler("/js/**").addResourceLocations("/js/");
+	}
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**");
 	}
 
 }

--- a/src/main/java/uk/org/funcube/fcdw/config/AppConfig.java
+++ b/src/main/java/uk/org/funcube/fcdw/config/AppConfig.java
@@ -1,18 +1,18 @@
 /*
 	This file is part of the FUNcube Data Warehouse
 
-    The FUNcube Data Warehouse is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 2 of the License, or
-    (at your option) any later version.
+	The FUNcube Data Warehouse is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
 
-    The FUNcube Data Warehouse is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	The FUNcube Data Warehouse is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with The FUNcube Data Warehouse.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with The FUNcube Data Warehouse.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 package uk.org.funcube.fcdw.config;
@@ -49,10 +49,10 @@ import uk.org.funcube.fcdw.service.PredictorService;
 public class AppConfig extends WebMvcConfigurerAdapter {
 
 	public AppConfig() {
-        super();
-    }
+		super();
+	}
 
-    @Override
+	@Override
 	public void configureDefaultServletHandling(
 			final DefaultServletHandlerConfigurer configurer) {
 		configurer.enable();
@@ -77,32 +77,32 @@ public class AppConfig extends WebMvcConfigurerAdapter {
 	FitterMessageProcessor fitterMessageProcessor() {
 		return new FitterMessageProcessorImpl();
 	}
-	
+
 	@Bean
 	WodCsvExtractor wodCsvExtractor() {
 		return new WodCsvExtractor();
 	}
-	
+
 	@Bean
 	HighResCsvExtractor highResCsvExtractor() {
 		return new HighResCsvExtractor();
 	}
-    
-    @Bean
-    HighRes24CsvExtractor highRes24CsvExtractor() {
-        return new HighRes24CsvExtractor();
-    }
-	
+
+	@Bean
+	HighRes24CsvExtractor highRes24CsvExtractor() {
+		return new HighRes24CsvExtractor();
+	}
+
 	@Bean
 	RealTimeCsvExtractor realTimeCsvExtractor() {
 		return new RealTimeCsvExtractor();
 	}
-	
+
 	@Bean
 	TleProcessor tleProcessor() {
 		return new TleProcessor();
 	}
-	
+
 	@Bean
 	PredictorService predictorService() {
 		return new PredictorService();


### PR DESCRIPTION
Making a request to the warehouse API from the browser isn't currently possible because the [CORS header](https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-cors) isn't set. 

I'm not sure if it's intentional, but this restrictive setup would essentially prevent any web-based service or client from using the API directly. If you don't mind third-party apps integrating with the warehouse, this PR will enable CORS headers on API endpoints to allow that.